### PR TITLE
Fix import paths and run gofmt on whole code.

### DIFF
--- a/bender.go
+++ b/bender.go
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 package bender
 
@@ -63,7 +63,7 @@ type EndRequestEvent struct {
 	// The response data returned by the request executor
 	Response interface{}
 	// An error or nil if there was no error
-	Err       error
+	Err error
 }
 
 // LoadTestThroughput starts a load test in which the caller controls the interval between requests
@@ -113,7 +113,7 @@ type WorkerSemaphore struct {
 // NewWorkerSemaphore creates an empty WorkerSemaphore (no workers).
 func NewWorkerSemaphore() *WorkerSemaphore {
 	// TODO(charles): Signal and Wait block due to permits being unbuffered, should we add a buffer?
-	return &WorkerSemaphore{permits:make(chan empty)}
+	return &WorkerSemaphore{permits: make(chan empty)}
 }
 
 // Signal adds a worker to the pool of workers that are currently sending requests. If no requests

--- a/bender_test.go
+++ b/bender_test.go
@@ -12,19 +12,19 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 package bender
 
 import (
-	"testing"
-	"reflect"
 	"errors"
+	"reflect"
+	"testing"
 )
 
 type Request struct{}
 
-func assertMessages(t *testing.T, cr chan interface{}, expected_msgs... interface{}) {
+func assertMessages(t *testing.T, cr chan interface{}, expected_msgs ...interface{}) {
 	for _, msg := range expected_msgs {
 		actual_msg, ok := <-cr
 		if !ok {
@@ -50,7 +50,7 @@ func assertMessages(t *testing.T, cr chan interface{}, expected_msgs... interfac
 	}
 }
 
-func requests(rs... interface{}) chan interface{} {
+func requests(rs ...interface{}) chan interface{} {
 	c := make(chan interface{})
 	go func() {
 		for _, r := range rs {
@@ -92,7 +92,7 @@ func TestLoadTestThroughputOneSuccess(t *testing.T) {
 func TestLoadTestThroughputOneError(t *testing.T) {
 	cr := make(chan interface{})
 	LoadTestThroughput(UniformIntervalGenerator(0), requests(Request{}), errorExec, cr)
-	assertMessages(t, cr, &StartEvent{}, &WaitEvent{}, &StartRequestEvent{}, &EndRequestEvent{Err:errors.New("foo")}, &EndEvent{})
+	assertMessages(t, cr, &StartEvent{}, &WaitEvent{}, &StartRequestEvent{}, &EndRequestEvent{Err: errors.New("foo")}, &EndEvent{})
 }
 
 func TestLoadTestConcurrencyNoRequests(t *testing.T) {
@@ -110,5 +110,5 @@ func TestLoadTestConcurrencyOneSuccess(t *testing.T) {
 func TestLoadTestConcurrencyOneError(t *testing.T) {
 	cr := make(chan interface{})
 	LoadTestConcurrency(workers(1), requests(Request{}), errorExec, cr)
-	assertMessages(t, cr, &StartEvent{}, &StartRequestEvent{}, &EndRequestEvent{Err:errors.New("foo")}, &EndEvent{})
+	assertMessages(t, cr, &StartEvent{}, &StartRequestEvent{}, &EndRequestEvent{Err: errors.New("foo")}, &EndEvent{})
 }

--- a/doc.go
+++ b/doc.go
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 /*
 Package bender makes it easy to build load testing applications for services using protocols like
@@ -185,4 +185,3 @@ events from the channel, and how quickly the load tester is running. It is a goo
 proactively buffer this channel.
 */
 package bender
-

--- a/hist/hist.go
+++ b/hist/hist.go
@@ -12,30 +12,30 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 package hist
 
 import (
-	"sort"
-	"math"
 	"fmt"
+	"math"
+	"sort"
 	"time"
 )
 
 type Histogram struct {
-	start int
-	end   int
-	scale int
-	max int
-	n int
+	start  int
+	end    int
+	scale  int
+	max    int
+	n      int
 	errCnt int
-	total int
+	total  int
 	values []int
 }
 
 func NewHistogram(max int, scale int) *Histogram {
-	return &Histogram{0, 0, scale, max, 0, 0, 0, make([]int, max + 1)}
+	return &Histogram{0, 0, scale, max, 0, 0, 0, make([]int, max+1)}
 }
 
 func (h *Histogram) Start(t int) {
@@ -73,17 +73,17 @@ func (h *Histogram) Percentiles(percentiles ...float64) []int {
 	sort.Sort(sort.Float64Slice(percentiles))
 
 	accum := 0
-	p_idx := int(math.Max(1.0, percentiles[0] * float64(h.n)))
+	p_idx := int(math.Max(1.0, percentiles[0]*float64(h.n)))
 	for i, j := 0, 0; i < len(percentiles) && j < len(h.values); j++ {
 		accum += h.values[j]
 
-		for ; accum >= p_idx; {
+		for accum >= p_idx {
 			result[i] = j
 			i++
 			if i >= len(percentiles) {
 				break
 			}
-			p_idx = int(math.Max(1.0, percentiles[i] * float64(h.n)))
+			p_idx = int(math.Max(1.0, percentiles[i]*float64(h.n)))
 		}
 	}
 
@@ -101,22 +101,22 @@ func (h *Histogram) ErrorPercent() float64 {
 func (h *Histogram) String() string {
 	ps := h.Percentiles(0.0, 0.5, 0.9, 0.95, 0.99, 0.999, 0.9999, 1.0)
 	s := "Percentiles:\n" +
-	     " Min:     %d\n" +
-	     " Median:  %d\n" +
-	     " 90th:    %d\n" +
-	     " 99th:    %d\n" +
-	     " 99.9th:  %d\n" +
-	     " 99.99th: %d\n" +
-	     " Max:     %d\n" +
-	     "Stats:\n" +
-	     " Average: %f\n" +
-	     " Total requests: %d\n" +
-		 " Elapsed Time (sec): %.4f\n" +
-		 " Average QPS: %.2f\n" +
-	     " Errors: %d\n" +
-	     " Percent errors: %.2f\n"
-	elapsedSecs := float64(h.end - h.start) / float64(time.Second)
+		" Min:     %d\n" +
+		" Median:  %d\n" +
+		" 90th:    %d\n" +
+		" 99th:    %d\n" +
+		" 99.9th:  %d\n" +
+		" 99.99th: %d\n" +
+		" Max:     %d\n" +
+		"Stats:\n" +
+		" Average: %f\n" +
+		" Total requests: %d\n" +
+		" Elapsed Time (sec): %.4f\n" +
+		" Average QPS: %.2f\n" +
+		" Errors: %d\n" +
+		" Percent errors: %.2f\n"
+	elapsedSecs := float64(h.end-h.start) / float64(time.Second)
 	averageQPS := float64(h.n) / elapsedSecs
 	return fmt.Sprintf(s, ps[0], ps[1], ps[2], ps[3], ps[4], ps[5], ps[6],
-	                   h.Average(), h.n, elapsedSecs, averageQPS, h.errCnt, h.ErrorPercent())
+		h.Average(), h.n, elapsedSecs, averageQPS, h.errCnt, h.ErrorPercent())
 }

--- a/hist/hist_test.go
+++ b/hist/hist_test.go
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 package hist
 

--- a/http/http.go
+++ b/http/http.go
@@ -12,14 +12,15 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 package http
 
 import (
-	"net/http"
 	"io"
-	"github.com/Pinterest/bender"
+	"net/http"
+
+	"github.com/pinterest/bender"
 )
 
 type HttpBodyValidator func(request interface{}, body io.ReadCloser) error

--- a/intervals.go
+++ b/intervals.go
@@ -12,13 +12,13 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 package bender
 
 import (
-	"time"
 	"math/rand"
+	"time"
 )
 
 // ExponentialIntervalGenerator creates an IntervalGenerator that outputs exponentially distributed

--- a/recorders.go
+++ b/recorders.go
@@ -12,18 +12,19 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 package bender
 
 import (
 	"log"
-	"github.com/Pinterest/bender/hist"
+
+	"github.com/pinterest/bender/hist"
 )
 
 type Recorder func(interface{})
 
-func Record(c chan interface{}, recorders... Recorder) {
+func Record(c chan interface{}, recorders ...Recorder) {
 	for msg := range c {
 		for _, recorder := range recorders {
 			recorder(msg)
@@ -58,4 +59,3 @@ func NewHistogramRecorder(h *hist.Histogram) Recorder {
 		}
 	}
 }
-

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -12,21 +12,22 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 
 package thrift
 
 import (
-	"git.apache.org/thrift.git/lib/go/thrift"
 	"bytes"
-	"github.com/Pinterest/bender"
 	"math/rand"
 	"time"
+
+	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/pinterest/bender"
 )
 
 type ThriftClientExecutor func(interface{}, thrift.TTransport) (interface{}, error)
 
-func NewThriftRequestExec(tFac thrift.TTransportFactory, clientExec ThriftClientExecutor, timeout time.Duration, hosts... string) bender.RequestExecutor {
+func NewThriftRequestExec(tFac thrift.TTransportFactory, clientExec ThriftClientExecutor, timeout time.Duration, hosts ...string) bender.RequestExecutor {
 	return func(_ int64, request interface{}) (interface{}, error) {
 		addr := hosts[rand.Intn(len(hosts))]
 		socket, err := thrift.NewTSocketTimeout(addr, timeout)


### PR DESCRIPTION
Some import paths used a capital P in github.com/pinterest/bender which
results in multiple copies of bender after 'go get'-ing bender on systems
with case sensitive filesystems.

Additionally: Run gofmt on the whole source.
