### PR TITLE
Fix go vet error in bender_test.go

### DIFF
--- a/bender_test.go
+++ b/bender_test.go
@@ -40,11 +40,11 @@ func assertMessages(t *testing.T, cr chan interface{}, expected_msgs ...interfac
 		switch m := actual_msg.(type) {
 		case *EndRequestEvent:
 			if m.Err != nil && msg.(*EndRequestEvent).Err == nil {
-				t.Errorf("Expected EndRequestEvent with no error (%s), but got EndRequestEvent with an error (%s)", msg, m)
+				t.Errorf("Expected EndRequestEvent with no error (%+v), but got EndRequestEvent with an error (%+v)", msg, m)
 			}
 
 			if m.Err == nil && msg.(*EndRequestEvent).Err != nil {
-				t.Errorf("Expected EndRequestEvent with an error (%s), but got EndRequestEvent with no error (%s)", msg, m)
+				t.Errorf("Expected EndRequestEvent with an error (%+v), but got EndRequestEvent with no error (%+v)", msg, m)
 			}
 		}
 	}


### PR DESCRIPTION
go vet ./... was complaining. This fixes the issue.

``` shell
go vet ./...
bender_test.go:43: arg m for printf verb %s of wrong type: *bender.EndRequestEvent
bender_test.go:47: arg m for printf verb %s of wrong type: *bender.EndRequestEvent
exit status 1
```
