### PR TITLE
HttpBodyValidator to HttpResponseValidator

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -17,15 +17,14 @@ limitations under the License.
 package http
 
 import (
-	"io"
 	"net/http"
 
 	"github.com/pinterest/bender"
 )
 
-type HttpBodyValidator func(request interface{}, body io.ReadCloser) error
+type HttpResponseValidator func(request interface{}, resp *http.Response) error
 
-func CreateHttpExecutor(tr *http.Transport, client *http.Client, bodyValidator HttpBodyValidator) bender.RequestExecutor {
+func CreateHttpExecutor(tr *http.Transport, client *http.Client, responseValidator HttpResponseValidator) bender.RequestExecutor {
 	if tr == nil {
 		tr = &http.Transport{}
 		client = &http.Client{Transport: tr}
@@ -39,8 +38,7 @@ func CreateHttpExecutor(tr *http.Transport, client *http.Client, bodyValidator H
 		if err != nil {
 			return nil, err
 		}
-		defer resp.Body.Close()
-		err = bodyValidator(request, resp.Body)
+		err = responseValidator(request, resp)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hi~
 
   It's better to use validator to check `HTTP Response` than `HTTP Body`..

   we often use `HTTP Status Code` to build restful api ... so except body, we also need to check http status at first, if error then body..

   Other people so need to check HTTP header...e.g. check Redirect URL

   It's better not limit bender's api to `check body` and let user check whole response~ although it maybe incompatible to old version, but I think it's worth to changing