### PR TITLE
http tutorial: fix signature of request executor

### DIFF
--- a/http/TUTORIAL.md
+++ b/http/TUTORIAL.md
@@ -196,8 +196,8 @@ them to the service. We will use a helper function from Bender's http library to
 request:
 
 ```
-func bodyValidator(request interface{}, body io.ReadCloser) error {
-	bytes, err := ioutil.ReadAll(body)
+func bodyValidator(request interface{}, resp *http.Response) error {
+	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -305,8 +305,8 @@ func SyntheticHttpRequests(n int) chan interface{} {
 	return c
 }
 
-func bodyValidator(request interface{}, body io.ReadCloser) error {
-	bytes, err := ioutil.ReadAll(body)
+func bodyValidator(request interface{}, resp *http.Response) error {
+	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Code example in the http tutorial does not compile, due to the changes in 517d9c26bbd3033ed3df716937d298336ecfa180
