### PR TITLE
Fix UniformIntervalGenerator

### DIFF
--- a/bender_test.go
+++ b/bender_test.go
@@ -79,19 +79,19 @@ func errorExec(int64, interface{}) (interface{}, error) {
 
 func TestLoadTestThroughputNoRequests(t *testing.T) {
 	cr := make(chan interface{})
-	LoadTestThroughput(UniformIntervalGenerator(0), requests(), noOpExec, cr)
+	LoadTestThroughput(UniformIntervalGenerator(1e9), requests(), noOpExec, cr)
 	assertMessages(t, cr, &StartEvent{}, &EndEvent{})
 }
 
 func TestLoadTestThroughputOneSuccess(t *testing.T) {
 	cr := make(chan interface{})
-	LoadTestThroughput(UniformIntervalGenerator(0), requests(Request{}), noOpExec, cr)
+	LoadTestThroughput(UniformIntervalGenerator(1e9), requests(Request{}), noOpExec, cr)
 	assertMessages(t, cr, &StartEvent{}, &WaitEvent{}, &StartRequestEvent{}, &EndRequestEvent{}, &EndEvent{})
 }
 
 func TestLoadTestThroughputOneError(t *testing.T) {
 	cr := make(chan interface{})
-	LoadTestThroughput(UniformIntervalGenerator(0), requests(Request{}), errorExec, cr)
+	LoadTestThroughput(UniformIntervalGenerator(1e9), requests(Request{}), errorExec, cr)
 	assertMessages(t, cr, &StartEvent{}, &WaitEvent{}, &StartRequestEvent{}, &EndRequestEvent{Err: errors.New("foo")}, &EndEvent{})
 }
 

--- a/intervals.go
+++ b/intervals.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bender
 
 import (
+	"math"
 	"math/rand"
 	"time"
 )
@@ -36,7 +37,10 @@ func ExponentialIntervalGenerator(rate float64) IntervalGenerator {
 // UniformIntervalGenerator creates and IntervalGenerator that outputs 1/rate every time it is
 // called. Boring, right?
 func UniformIntervalGenerator(rate float64) IntervalGenerator {
-	irate := int64(rate / float64(time.Second))
+	var irate int64 = math.MaxInt64
+	if rate != 0.0 {
+		irate = int64(float64(time.Second) / rate)
+	}
 	return func(_ int64) int64 {
 		return irate
 	}


### PR DESCRIPTION
This PR intends on fixing https://github.com/pinterest/bender/issues/15 by moving the rate to the denominator.

I had to change the tests because a 0 QPS is non-sensible w.r.t. what the tests are trying to test.