### PR TITLE
Add safety check for the request type in dns executor

### DIFF
--- a/dns/TUTORIAL.md
+++ b/dns/TUTORIAL.md
@@ -198,7 +198,7 @@ request:
 ```go
 var responseIP = net.ParseIP("fd6c:1a5c:2b63::d8e9")
 
-func validator(_ interface{}, resp *dns.Msg) error {
+func validator(_, resp *dns.Msg) error {
 	if len(resp.Answer) != 1 {
 		return fmt.Errorf("response missing answer for query")
 	}
@@ -300,7 +300,7 @@ func SyntheticDNSRequests(n int) chan interface{} {
 	return c
 }
 
-func validator(_ interface{}, resp *dns.Msg) error {
+func validator(_, resp *dns.Msg) error {
 	if len(resp.Answer) != 1 {
 		return fmt.Errorf("response missing answer for query")
 	}

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -1,12 +1,14 @@
 package dns
 
 import (
+	"fmt"
+
 	"github.com/miekg/dns"
 	"github.com/pinterest/bender"
 )
 
 // ResponseValidator validates a DNS response.
-type ResponseValidator func(request interface{}, response *dns.Msg) error
+type ResponseValidator func(request, response *dns.Msg) error
 
 // CreateExecutor creates a new DNS RequestExecutor.
 func CreateExecutor(client *dns.Client, responseValidator ResponseValidator, hosts ...string) bender.RequestExecutor {
@@ -16,14 +18,17 @@ func CreateExecutor(client *dns.Client, responseValidator ResponseValidator, hos
 
 	var i int
 	return func(_ int64, request interface{}) (interface{}, error) {
-		msg := request.(*dns.Msg)
+		msg, ok := request.(*dns.Msg)
+		if !ok {
+			return nil, fmt.Errorf("invalid request type %T, want: *dns.Msg", request)
+		}
 		addr := hosts[i]
 		i = (i + 1) % len(hosts)
 		resp, _, err := client.Exchange(msg, addr)
 		if err != nil {
 			return nil, err
 		}
-		if err = responseValidator(request, resp); err != nil {
+		if err = responseValidator(msg, resp); err != nil {
 			return nil, err
 		}
 		return resp, nil

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -1,0 +1,19 @@
+package dns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func validator(_, _ *dns.Msg) error {
+	return nil
+}
+
+func TestExecutorTypeCheck(t *testing.T) {
+	executor := CreateExecutor(nil, validator, ":54321")
+	_, err := executor(0, dns.Msg{})
+	if err == nil || err.Error() != "invalid request type dns.Msg, want: *dns.Msg" {
+		t.Errorf("Expected executor to fail with invalid request type error, got (%s)", err)
+	}
+}


### PR DESCRIPTION
This error should never occur if proper requests are put into the channel, but in case of a mistake throwing this error may help to find the error easier. For validation we may pass already casted message, unlike the thrift library in DNS we know the type of the request.