### PR TITLE
fix thrift load tester program bug

### DIFF
--- a/thrift/TUTORIAL.md
+++ b/thrift/TUTORIAL.md
@@ -357,6 +357,7 @@ import (
 	"github.com/pinterest/bender/hist"
 	"fmt"
 	"time"
+    "strconv"
 	"$PKG/hellothrift/hello"
 )
 
@@ -365,7 +366,7 @@ func SyntheticRequests(n int) chan interface{} {
 	go func() {
 		for i := 0; i < n; i++ {
 			request := hello.NewHelloRequest()
-			request.Message = "hello " + i
+			request.Message = "hello " + strconv.Itoa(i)
 			c <- request
 		}
 		close(c)

--- a/thrift/TUTORIAL.md
+++ b/thrift/TUTORIAL.md
@@ -357,7 +357,7 @@ import (
 	"github.com/pinterest/bender/hist"
 	"fmt"
 	"time"
-    "strconv"
+        "strconv"
 	"$PKG/hellothrift/hello"
 )
 


### PR DESCRIPTION
your thrift load tester program can't run normally, go can't convert int into string automatically.