### PR TITLE
Fix location of github.com/mdlayher/eui64

### DIFF
--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	"github.com/insomniacslk/dhcp/dhcpv6/async"
-	"github.com/mdlayher/eui64"
+	"github.com/mdlayher/netx/eui64"
 	"github.com/pinterest/bender"
 )
 


### PR DESCRIPTION
The `github.com/mdlayher/eui64` package used in `./dhcpv6/dhcpv6.go` has been relocated to `github.com/mdlayher/netx/eui64`. Without this fix, bender and any libraries that depend on it cannot easily be installed successfully.