### PR TITLE
Update dependency mdlayher/eui64 -> mdlayher/netx/eui64

### DIFF
--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	"github.com/insomniacslk/dhcp/dhcpv6/async"
-	"github.com/mdlayher/eui64"
+	"github.com/mdlayher/netx/eui64"
 	"github.com/pinterest/bender"
 )
 


### PR DESCRIPTION
The package has been moved to a different repository therefore failing builds. Tests fails due to unrelated change in thrift function arguments mentioned in https://github.com/pinterest/bender/issues/40.