### PR TITLE
Add PITS Global Data Recovery Services to the adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,3 +6,4 @@ adds your information to this file.
 
 - [Facebook](https://www.facebook.com/) as [FBender](https://github.com/facebookincubator/fbender)
 - [Pinterest](https://www.pinterest.com/)
+- [PITS Global Data Recovery Services](https://www.pitsdatarecovery.net/)


### PR DESCRIPTION
This pull request creates new entry to the adopters list located in ADOPTERS.md file